### PR TITLE
fix: add explicit timeout and wait strategy for page navigation

### DIFF
--- a/src/balance.py
+++ b/src/balance.py
@@ -22,8 +22,8 @@ def get_balance(page: Page) -> dict:
         }
     """
     # Navigate to My Page
-    page.goto("https://www.dhlottery.co.kr/mypage/home")
-    page.wait_for_load_state("networkidle")
+    page.goto("https://www.dhlottery.co.kr/mypage/home", timeout=30000, wait_until="domcontentloaded")
+    page.wait_for_load_state("networkidle", timeout=30000)
     
     # Get deposit balance (예치금 잔액)
     # Selector: #totalAmt (contains only number like "35,000")

--- a/src/charge.py
+++ b/src/charge.py
@@ -139,7 +139,7 @@ def charge_deposit(page: Page, amount: int) -> bool:
         return False
 
     print(f"Navigating to charge page for {amount:,} won...")
-    page.goto("https://www.dhlottery.co.kr/mypage/mndpChrg")
+    page.goto("https://www.dhlottery.co.kr/mypage/mndpChrg", timeout=30000, wait_until="domcontentloaded")
     
     # 간편충전 선택
     page.click("text=간편충전")

--- a/src/login.py
+++ b/src/login.py
@@ -49,7 +49,7 @@ def login(page: Page) -> None:
         raise ValueError("❌ USER_ID or PASSWD not found in environment variables.")
     
     print('Starting login process...')
-    page.goto("https://www.dhlottery.co.kr/login")
+    page.goto("https://www.dhlottery.co.kr/login", timeout=30000, wait_until="domcontentloaded")
     
     page.locator("#inpUserId").fill(USER_ID)
     page.locator("#inpUserPswdEncn").fill(PASSWD)

--- a/src/lotto645.py
+++ b/src/lotto645.py
@@ -111,7 +111,7 @@ def run(playwright: Playwright, auto_games: int, manual_numbers: list) -> None:
         login(page)
 
         # Navigate to game page
-        page.goto(url="https://ol.dhlottery.co.kr/olotto/game/game645.do")
+        page.goto(url="https://ol.dhlottery.co.kr/olotto/game/game645.do", timeout=30000, wait_until="domcontentloaded")
         print('✅ Navigated to Lotto 6/45 page')
 
         # Dismiss popup if present

--- a/src/lotto720.py
+++ b/src/lotto720.py
@@ -30,7 +30,7 @@ def run(playwright: Playwright) -> None:
     try:
         # Navigate to the Wrapper Page (TotalGame.jsp) which handles session sync correctly
         print("🚀 Navigating to Lotto 720 Wrapper page...")
-        page.goto("https://el.dhlottery.co.kr/game/TotalGame.jsp?LottoId=LP72")
+        page.goto("https://el.dhlottery.co.kr/game/TotalGame.jsp?LottoId=LP72", timeout=30000, wait_until="domcontentloaded")
         
         # Access the game iframe
         # The actual game UI is loaded inside this iframe


### PR DESCRIPTION
- Add timeout=30000 (default) for all page.goto() calls
- Change wait strategy from 'load' to 'domcontentloaded' for faster navigation
- Add explicit timeout to networkidle wait in balance.py

로컬에서 실행해보니 dom content loaded 전에 스크립트가 실행되어 오류가 발생하였습니다.
수정된 패치를 올립니다.

덕분에 편하게 구매하였습니다. 감사합니다.